### PR TITLE
Sanity check to enforce IPv4 address

### DIFF
--- a/lib/jgeoip.js
+++ b/lib/jgeoip.js
@@ -565,7 +565,14 @@ function _expandIP(ip) {
     // From: '8.8.4.4'
     // To: [0, 0, 0, 0, 0, 0, 8 * 256 + 8, 4 * 256 + 4]
     //return ip.split('.').map(function(i) { return parseInt(i, 10); });
-    ip = ip.split('.').map(function(i) { return parseInt(i, 10); });
+    ip = ip.split('.').map(function(i) { 
+        var partI = parseInt(i, 10);
+        if(partI > 255) {
+            throw new Error('This IP ' + ip + ' is not a valid IPv4 address!');
+        } else {
+            return partI;
+        } 
+    });
     return [0, 0, 0, 0, 0, 0, ip[0] * 256 + ip[1], ip[2] * 256 + ip[3]];
   }
   else if (regexIPv6c.test(ip)) {

--- a/test/main.js
+++ b/test/main.js
@@ -19,7 +19,7 @@ var CMD        = './test/geolite2_download.sh'
   , IPV6       = '2001:4860:4860::8888'
   , IPV4TO6MAP = '::ffff:54.88.56.156'
   , PRIVATEIP  = '192.168.98.1'
-  , FALSEIP4   = '8.8.8'
+  , FALSEIP4s   = ['8.8.8', '8.8.8.-8', '500.500.500.500']
   , FALSEIP6   = '2001:4860:4860:8888'
   ;
 
@@ -357,14 +357,17 @@ describe('jGeoIP2', function() {
       expect(geoip.getRecord()).to.be.null;
     });
 
-    it('Expects it to throw an error for the malformed IPv4 address ' + FALSEIP4 + '.', function() {
-      try {
-        test = false;
-        geoip.getRecord(FALSEIP4);
-      } catch (e) {
-        test = true;
-      }
-      expect(test).to.be.true;
+    FALSEIP4s.forEach(function(FALSEIP4) {
+      it('Expects it to throw an error for the malformed IPv4 address ' + FALSEIP4 + '.', function() {
+        try {
+          test = false;
+          geoip.getRecord(FALSEIP4);
+        } catch (e) {
+          test = true;
+        }
+        expect(test).to.be.true;
+      });
+    
     });
 
     it('Expects it to throw an error for the malformed IPv6 address ' + FALSEIP6 + '.', function() {


### PR DESCRIPTION
Currently, there is a missing sanity check which allows invalid IPv4 address to be submitted to API, e.g. 500.500.500.500.  This added check will throw Error if any IPv4 component is greater than 255.
